### PR TITLE
Fix usage printing in get_buffer.py

### DIFF
--- a/bin/get_buffer.py
+++ b/bin/get_buffer.py
@@ -17,7 +17,7 @@ def get_buffer_content(tab, win, lines):
 
 
 def usage():
-    print("%s: [tab] [win] [lines]") % sys.argv[0]
+    print("%s: [tab] [win] [lines]" % sys.argv[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix get_buffer.py usage message to print correctly

## Testing
- `python3 -m py_compile bin/get_buffer.py`

------
https://chatgpt.com/codex/tasks/task_e_684d815c07c8832785feac85633eb105