### PR TITLE
Fix typos

### DIFF
--- a/autoload/vimrc/fzf/dir.vim
+++ b/autoload/vimrc/fzf/dir.vim
@@ -139,7 +139,7 @@ function! vimrc#fzf#dir#all_files(folder, bang) abort
         \ a:bang)
 endfunction
 
-" Custom files, using ':' to seperate folder and option and pattern
+" Custom files, using ':' to separate folder and option and pattern
 " TODO Review arguments
 function! vimrc#fzf#dir#custom_files(command, bang) abort
   let command_parts = split(a:command, ':', 1)

--- a/autoload/vimrc/fzf/rg.vim
+++ b/autoload/vimrc/fzf/rg.vim
@@ -84,7 +84,7 @@ function! vimrc#fzf#rg#rga(command, bang) abort
         \ a:bang)
 endfunction
 
-" Matched files, using ':' to seperate folder and option and pattern
+" Matched files, using ':' to separate folder and option and pattern
 " TODO Review arguments
 function! vimrc#fzf#rg#matched_files(command, bang) abort
   let command_parts = split(a:command, ':', 1)

--- a/autoload/vimrc/tui.vim
+++ b/autoload/vimrc/tui.vim
@@ -1,6 +1,6 @@
 " For TUI support
 let s:shells = [&shell, 'bash', 'zsh', 'fish', 'powershell', 'ash', 'nu']
-" NOTE: Use env for passing enviroment variablet to tui processes
+" NOTE: Use env for passing environment variables to tui processes
 let s:tui_processes = ['htop', 'atop', 'btm', 'broot', 'sr', 'ranger', 'nnn', 'vifm', 'fff', 'lf', 'lazygit', 'gitui', 'bandwhich', 'xplr', 'jless', 'env', 'yazi', 'mprocs']
 let s:floaterm_wrappers = extend(['broot', 'fff', 'fzf', 'lf', 'nnn', 'ranger', 'rg', 'vifm', 'xplr'], ['vifm_dir'])
 

--- a/lua/core/float.lua
+++ b/lua/core/float.lua
@@ -112,7 +112,7 @@ float.setup = function()
   vim.keymap.set("t", "<M-q><M-,><M-r>", [[<C-\><C-N>:VimrcFloatRemove<CR>]], { silent = true })
 
   -- TODO For nested neovim
-  -- Need to implement different prefix_count for diferrent key mappings in
+  -- Need to implement different prefix_count for different key mappings in
   -- nested_neovim.vim
   -- }}}
 end


### PR DESCRIPTION
## Summary
- correct env var comment in `autoload/vimrc/tui.vim`
- fix typos in FZF scripts
- fix typo in float comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d8b823bc88327808d5c0102fa26a5