### PR TITLE
Remove duplicate terminal keymaps

### DIFF
--- a/lua/core/float.lua
+++ b/lua/core/float.lua
@@ -94,22 +94,6 @@ float.setup = function()
   vim.keymap.set("t", "<M-q><M-,><M-k>", [[<C-\><C-N>:VimrcFloatNext<CR>]], { silent = true })
   vim.keymap.set("t", "<M-q><M-,><M-r>", [[<C-\><C-N>:VimrcFloatRemove<CR>]], { silent = true })
 
-  vim.keymap.set("t", "<M-q><M-,><M-l>", [[<C-\><C-N>:VimrcFloatToggle<CR>]], { silent = true })
-  vim.keymap.set(
-    "t",
-    "<M-q><M-,><M-n>",
-    [[<C-\><C-N>:execute 'VimrcFloatNew '.input('command: ', '', 'command')<CR>]],
-    { silent = true }
-  )
-  vim.keymap.set(
-    "t",
-    "<M-q><M-,><M-m>",
-    [[<C-\><C-N>:execute 'VimrcFloatNew! '.input('command: ', '', 'command')<CR>]],
-    { silent = true }
-  )
-  vim.keymap.set("t", "<M-q><M-,><M-j>", [[<C-\><C-N>:VimrcFloatPrev<CR>]], { silent = true })
-  vim.keymap.set("t", "<M-q><M-,><M-k>", [[<C-\><C-N>:VimrcFloatNext<CR>]], { silent = true })
-  vim.keymap.set("t", "<M-q><M-,><M-r>", [[<C-\><C-N>:VimrcFloatRemove<CR>]], { silent = true })
 
   -- TODO For nested neovim
   -- Need to implement different prefix_count for diferrent key mappings in


### PR DESCRIPTION
## Summary
- clean up duplicate key mappings in `float.lua`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d8cbd3ed08327979a3f8f280a0d3b