### PR TITLE
Fix FzfLua key mapping descriptions

### DIFF
--- a/lua/vimrc/plugins/fzf_lua.lua
+++ b/lua/vimrc/plugins/fzf_lua.lua
@@ -97,61 +97,60 @@ my_fzf_lua.setup_command = function()
 end
 
 my_fzf_lua.setup_mapping = function()
-  -- TODO: Add key mapping description
   -- TODO: `vim.ui.input()` do not complete, study why
   local fzf_lua_prefix = [[<Space>f]]
   local fzf_lua_lsp_prefix = [[<Space>l]]
   local fzf_lua_diagnostics_prefix = [[<Space>l]]
 
   -- General
-  vim.keymap.set("n", fzf_lua_prefix .. [[a]], [[<Cmd>FzfLua loclist<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[A]], [[<Cmd>FzfLua args<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[b]], [[<Cmd>FzfLua buffers<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[B]], [[<Cmd>FzfLua git_branches<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[c]], [[<Cmd>FzfLua git_bcommits<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[C]], [[<Cmd>FzfLua git_commits<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[f]], [[<Cmd>FzfLua files<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[g]], [[<Cmd>FzfLua git_files<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[G]], [[<Cmd>FzfLua live_grep_glob<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[h]], [[<Cmd>FzfLua help_tags<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[H]], [[<Cmd>FzfLua git_stash<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[i]], [[<Cmd>FzfLua live_grep<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[I]], [[<Cmd>FzfLua live_grep_native<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[j]], [[<Cmd>FzfLua jumps<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[k]], [[<Cmd>FzfLua grep_cword<CR>]])
-  vim.keymap.set("x", fzf_lua_prefix .. [[k]], [[<Cmd>FzfLua grep_visual<CR>]]) -- For muscle memory of grepping visual selection using fzf.vim
-  vim.keymap.set("n", fzf_lua_prefix .. [[K]], [[<Cmd>FzfLua grep_cWORD<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[l]], [[<Cmd>FzfLua blines<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[L]], [[<Cmd>FzfLua lines<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[m]], [[<Cmd>FzfLua oldfiles<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[p]], [[<Cmd>FzfLua tags_grep<CR>]])
-  vim.keymap.set("x", fzf_lua_prefix .. [[p]], [[<Cmd>FzfLua tags_grep_visual<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[P]], [[<Cmd>FzfLua tags_grep_cword<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[q]], [[<Cmd>FzfLua quickfix<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[Q]], [[<Cmd>FzfLua grep_quickfix<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[r]], [[<Cmd>FzfLua grep<CR>]])
-  vim.keymap.set("x", fzf_lua_prefix .. [[r]], [[<Cmd>FzfLua grep_visual<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[R]], [[<Cmd>FzfLua grep_project<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[s]], [[<Cmd>FzfLua git_status<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[S]], [[<Cmd>FzfLua spell_suggest<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[t]], [[<Cmd>FzfLua btags<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[T]], [[<Cmd>FzfLua tags<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[u]], [[<Cmd>FzfLua resume<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[U]], [[<Cmd>FzfLua live_grep_resume<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[v]], [[<Cmd>FzfLua colorschemes<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[w]], [[<Cmd>FzfLua tabs<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[x]], [[<Cmd>FzfLua changes<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[X]], [[<Cmd>FzfLua spell_suggest<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[y]], [[<Cmd>FzfLua filetypes<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[Y]], [[<Cmd>FzfLua highlights<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[,]], [[<Cmd>FzfLua builtin<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[`]], [[<Cmd>FzfLua marks<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[']], [[<Cmd>FzfLua registers<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[;]], [[<Cmd>FzfLua commands<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[:]], [[<Cmd>FzfLua command_history<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[/]], [[<Cmd>FzfLua search_history<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[<Tab>]], [[<Cmd>FzfLua keymaps<CR>]])
-  vim.keymap.set("n", fzf_lua_prefix .. [[<F1>]], [[<Cmd>FzfLua man_pages<CR>]])
+  vim.keymap.set("n", fzf_lua_prefix .. [[a]], [[<Cmd>FzfLua loclist<CR>]], { desc = "FzfLua loclist" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[A]], [[<Cmd>FzfLua args<CR>]], { desc = "FzfLua args" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[b]], [[<Cmd>FzfLua buffers<CR>]], { desc = "FzfLua buffers" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[B]], [[<Cmd>FzfLua git_branches<CR>]], { desc = "FzfLua git_branches" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[c]], [[<Cmd>FzfLua git_bcommits<CR>]], { desc = "FzfLua git_bcommits" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[C]], [[<Cmd>FzfLua git_commits<CR>]], { desc = "FzfLua git_commits" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[f]], [[<Cmd>FzfLua files<CR>]], { desc = "FzfLua files" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[g]], [[<Cmd>FzfLua git_files<CR>]], { desc = "FzfLua git_files" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[G]], [[<Cmd>FzfLua live_grep_glob<CR>]], { desc = "FzfLua live_grep_glob" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[h]], [[<Cmd>FzfLua help_tags<CR>]], { desc = "FzfLua help_tags" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[H]], [[<Cmd>FzfLua git_stash<CR>]], { desc = "FzfLua git_stash" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[i]], [[<Cmd>FzfLua live_grep<CR>]], { desc = "FzfLua live_grep" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[I]], [[<Cmd>FzfLua live_grep_native<CR>]], { desc = "FzfLua live_grep_native" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[j]], [[<Cmd>FzfLua jumps<CR>]], { desc = "FzfLua jumps" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[k]], [[<Cmd>FzfLua grep_cword<CR>]], { desc = "FzfLua grep_cword" })
+  vim.keymap.set("x", fzf_lua_prefix .. [[k]], [[<Cmd>FzfLua grep_visual<CR>]], { desc = "FzfLua grep_visual" }) -- For muscle memory of grepping visual selection using fzf.vim
+  vim.keymap.set("n", fzf_lua_prefix .. [[K]], [[<Cmd>FzfLua grep_cWORD<CR>]], { desc = "FzfLua grep_cWORD" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[l]], [[<Cmd>FzfLua blines<CR>]], { desc = "FzfLua blines" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[L]], [[<Cmd>FzfLua lines<CR>]], { desc = "FzfLua lines" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[m]], [[<Cmd>FzfLua oldfiles<CR>]], { desc = "FzfLua oldfiles" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[p]], [[<Cmd>FzfLua tags_grep<CR>]], { desc = "FzfLua tags_grep" })
+  vim.keymap.set("x", fzf_lua_prefix .. [[p]], [[<Cmd>FzfLua tags_grep_visual<CR>]], { desc = "FzfLua tags_grep_visual" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[P]], [[<Cmd>FzfLua tags_grep_cword<CR>]], { desc = "FzfLua tags_grep_cword" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[q]], [[<Cmd>FzfLua quickfix<CR>]], { desc = "FzfLua quickfix" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[Q]], [[<Cmd>FzfLua grep_quickfix<CR>]], { desc = "FzfLua grep_quickfix" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[r]], [[<Cmd>FzfLua grep<CR>]], { desc = "FzfLua grep" })
+  vim.keymap.set("x", fzf_lua_prefix .. [[r]], [[<Cmd>FzfLua grep_visual<CR>]], { desc = "FzfLua grep_visual" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[R]], [[<Cmd>FzfLua grep_project<CR>]], { desc = "FzfLua grep_project" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[s]], [[<Cmd>FzfLua git_status<CR>]], { desc = "FzfLua git_status" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[S]], [[<Cmd>FzfLua spell_suggest<CR>]], { desc = "FzfLua spell_suggest" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[t]], [[<Cmd>FzfLua btags<CR>]], { desc = "FzfLua btags" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[T]], [[<Cmd>FzfLua tags<CR>]], { desc = "FzfLua tags" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[u]], [[<Cmd>FzfLua resume<CR>]], { desc = "FzfLua resume" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[U]], [[<Cmd>FzfLua live_grep_resume<CR>]], { desc = "FzfLua live_grep_resume" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[v]], [[<Cmd>FzfLua colorschemes<CR>]], { desc = "FzfLua colorschemes" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[w]], [[<Cmd>FzfLua tabs<CR>]], { desc = "FzfLua tabs" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[x]], [[<Cmd>FzfLua changes<CR>]], { desc = "FzfLua changes" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[X]], [[<Cmd>FzfLua spell_suggest<CR>]], { desc = "FzfLua spell_suggest" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[y]], [[<Cmd>FzfLua filetypes<CR>]], { desc = "FzfLua filetypes" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[Y]], [[<Cmd>FzfLua highlights<CR>]], { desc = "FzfLua highlights" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[,]], [[<Cmd>FzfLua builtin<CR>]], { desc = "FzfLua builtin" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[`]], [[<Cmd>FzfLua marks<CR>]], { desc = "FzfLua marks" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[']], [[<Cmd>FzfLua registers<CR>]], { desc = "FzfLua registers" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[;]], [[<Cmd>FzfLua commands<CR>]], { desc = "FzfLua commands" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[:]], [[<Cmd>FzfLua command_history<CR>]], { desc = "FzfLua command_history" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[/]], [[<Cmd>FzfLua search_history<CR>]], { desc = "FzfLua search_history" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[<Tab>]], [[<Cmd>FzfLua keymaps<CR>]], { desc = "FzfLua keymaps" })
+  vim.keymap.set("n", fzf_lua_prefix .. [[<F1>]], [[<Cmd>FzfLua man_pages<CR>]], { desc = "FzfLua man_pages" })
 
   -- Files
   vim.keymap.set("n", fzf_lua_prefix .. "n", function()
@@ -222,19 +221,19 @@ my_fzf_lua.setup_mapping = function()
   end, { desc = "Quickfix with build error" })
 
   -- Lsp
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "r", "<Cmd>FzfLua lsp_references<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "d", "<Cmd>FzfLua lsp_definitions<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "D", "<Cmd>FzfLua lsp_declarations<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "t", "<Cmd>FzfLua lsp_typedefs<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "i", "<Cmd>FzfLua lsp_implementations<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "a", "<Cmd>FzfLua lsp_code_actions<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "o", "<Cmd>FzfLua lsp_document_symbols<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "S", "<Cmd>FzfLua lsp_workspace_symbols<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "s", "<Cmd>FzfLua lsp_live_workspace_symbols<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "c", "<Cmd>FzfLua lsp_document_diagnostics<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. "C", "<Cmd>FzfLua lsp_workspace_diagnostics<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. ",", "<Cmd>FzfLua lsp_incoming_calls<CR>")
-  vim.keymap.set("n", fzf_lua_lsp_prefix .. ".", "<Cmd>FzfLua lsp_outgoing_calls<CR>")
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "r", "<Cmd>FzfLua lsp_references<CR>", { desc = "FzfLua lsp_references" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "d", "<Cmd>FzfLua lsp_definitions<CR>", { desc = "FzfLua lsp_definitions" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "D", "<Cmd>FzfLua lsp_declarations<CR>", { desc = "FzfLua lsp_declarations" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "t", "<Cmd>FzfLua lsp_typedefs<CR>", { desc = "FzfLua lsp_typedefs" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "i", "<Cmd>FzfLua lsp_implementations<CR>", { desc = "FzfLua lsp_implementations" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "a", "<Cmd>FzfLua lsp_code_actions<CR>", { desc = "FzfLua lsp_code_actions" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "o", "<Cmd>FzfLua lsp_document_symbols<CR>", { desc = "FzfLua lsp_document_symbols" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "S", "<Cmd>FzfLua lsp_workspace_symbols<CR>", { desc = "FzfLua lsp_workspace_symbols" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "s", "<Cmd>FzfLua lsp_live_workspace_symbols<CR>", { desc = "FzfLua lsp_live_workspace_symbols" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "c", "<Cmd>FzfLua lsp_document_diagnostics<CR>", { desc = "FzfLua lsp_document_diagnostics" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. "C", "<Cmd>FzfLua lsp_workspace_diagnostics<CR>", { desc = "FzfLua lsp_workspace_diagnostics" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. ",", "<Cmd>FzfLua lsp_incoming_calls<CR>", { desc = "FzfLua lsp_incoming_calls" })
+  vim.keymap.set("n", fzf_lua_lsp_prefix .. ".", "<Cmd>FzfLua lsp_outgoing_calls<CR>", { desc = "FzfLua lsp_outgoing_calls" })
 
   vim.keymap.set("n", fzf_lua_lsp_prefix .. "Q", function()
     fzf_lua.lsp_workspace_symbols({ query = vim.fn.input("Query: ") })
@@ -250,14 +249,44 @@ my_fzf_lua.setup_mapping = function()
   end, { desc = "Lsp live workspace symbols with cword" })
 
   -- Diagnostics
-  vim.keymap.set("n", fzf_lua_diagnostics_prefix .. "x", "<Cmd>FzfLua diagnostics_document<CR>")
-  vim.keymap.set("n", fzf_lua_diagnostics_prefix .. "X", "<Cmd>FzfLua diagnostics_workspace<CR>")
+  vim.keymap.set(
+    "n",
+    fzf_lua_diagnostics_prefix .. "x",
+    "<Cmd>FzfLua diagnostics_document<CR>",
+    { desc = "FzfLua diagnostics_document" }
+  )
+  vim.keymap.set(
+    "n",
+    fzf_lua_diagnostics_prefix .. "X",
+    "<Cmd>FzfLua diagnostics_workspace<CR>",
+    { desc = "FzfLua diagnostics_workspace" }
+  )
 
   -- Complete
-  vim.keymap.set("i", [[<C-Z><C-D>]], [[<Cmd>lua require("fzf-lua").complete_path()<CR>]])
-  vim.keymap.set("i", [[<C-Z><C-F>]], [[<Cmd>lua require("fzf-lua").complete_file()<CR>]])
-  vim.keymap.set("i", [[<C-Z><C-L>]], [[<Cmd>lua require("fzf-lua").complete_bline()<CR>]])
-  vim.keymap.set("i", [[<C-Z><M-l>]], [[<Cmd>lua require("fzf-lua").complete_line()<CR>]])
+  vim.keymap.set(
+    "i",
+    [[<C-Z><C-D>]],
+    [[<Cmd>lua require("fzf-lua").complete_path()<CR>]],
+    { desc = "FzfLua complete_path" }
+  )
+  vim.keymap.set(
+    "i",
+    [[<C-Z><C-F>]],
+    [[<Cmd>lua require("fzf-lua").complete_file()<CR>]],
+    { desc = "FzfLua complete_file" }
+  )
+  vim.keymap.set(
+    "i",
+    [[<C-Z><C-L>]],
+    [[<Cmd>lua require("fzf-lua").complete_bline()<CR>]],
+    { desc = "FzfLua complete_bline" }
+  )
+  vim.keymap.set(
+    "i",
+    [[<C-Z><M-l>]],
+    [[<Cmd>lua require("fzf-lua").complete_line()<CR>]],
+    { desc = "FzfLua complete_line" }
+  )
 
   -- Custom command
   vim.keymap.set("n", fzf_lua_prefix .. "<F2>", function()


### PR DESCRIPTION
## Summary
- add `desc` to all key mappings in `fzf_lua` plugin
- remove completed TODO comment

## Testing
- `busted` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db97cbf5483278ab259b5fdc07a73